### PR TITLE
[DEV-7216] PageHeader Refactor for Greater Consumer Flexibility in Toolbar

### DIFF
--- a/.storybook/stories/page-header.stories.mdx
+++ b/.storybook/stories/page-header.stories.mdx
@@ -1,10 +1,12 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { boolean } from "@storybook/addon-knobs";
 
 import PageHeader from '../../components/PageHeader';
 import ComingSoon from '../../components/messages/ComingSoon';
 import ShareIcon from '../../components/ShareIcon';
 import DownloadIconButton from '../../components/DownloadIconButton';
 import FiscalYearPicker from '../../components/FiscalYearPicker';
+import { Tooltip } from '../misc';
 
 <Meta
     title="Page Header"
@@ -30,7 +32,7 @@ The page header is sticky on scroll. You can pass `stickyBreakpoint` to specify 
                     latestFy={2021}
                     handleFyChange={() => {}} />,
                 <ShareIcon url='this-is-a-test-url.com' />,
-                <DownloadIconButton onClick={() => {}} downloadInFlight={false} />
+                <DownloadIconButton onClick={() => {}} downloadInFlight={boolean("Download In Flight", false)} tooltipComponent={<Tooltip />} isEnabled={boolean("Download Enabled", true)} />
             ]}>
             <ComingSoon />
         </PageHeader>

--- a/.storybook/stories/page-header.stories.mdx
+++ b/.storybook/stories/page-header.stories.mdx
@@ -2,6 +2,9 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 
 import PageHeader from '../../components/PageHeader';
 import ComingSoon from '../../components/messages/ComingSoon';
+import ShareIcon from '../../components/ShareIcon';
+import DownloadIconButton from '../../components/DownloadIconButton';
+import FiscalYearPicker from '../../components/FiscalYearPicker';
 
 <Meta
     title="Page Header"
@@ -19,41 +22,16 @@ The page header is sticky on scroll. You can pass `stickyBreakpoint` to specify 
 <Canvas>
     <Story name='w/ All Toolbar Options'>
         <PageHeader
+            overLine="Agency Profile"
             title="Department of Homeland Security"
-            fyProps={{
-                selectedFy: 2020,
-                latestFy: 2021,
-                handleFyChange: () => {}
-            }}
-            downloadProps={{
-                onClick: () => {},
-                downloadInFlight: false
-            }}
-            shareProps={{
-                url: 'this-is-a-test-url.com',
-                email: {
-                    subject: 'Example',
-                    body: ''
-                }
-            }}
-            overLine="Agency Profile">
-            <ComingSoon />
-        </PageHeader>
-    </Story>
-</Canvas>
-
-<Canvas>
-    <Story name='w/ Only Share'>
-        <PageHeader
-            title="Department of Homeland Security"
-            shareProps={{
-                url: 'this-is-a-test-url.com',
-                email: {
-                    subject: 'Example',
-                    body: ''
-                }
-            }}
-            overLine="Agency Profile">
+            toolBar={[
+                <FiscalYearPicker
+                    selectedFy={2020}
+                    latestFy={2021}
+                    handleFyChange={() => {}} />,
+                <ShareIcon url='this-is-a-test-url.com' />,
+                <DownloadIconButton onClick={() => {}} downloadInFlight={false} />
+            ]}>
             <ComingSoon />
         </PageHeader>
     </Story>

--- a/.storybook/stories/page-header.stories.mdx
+++ b/.storybook/stories/page-header.stories.mdx
@@ -23,19 +23,20 @@ The page header is sticky on scroll. You can pass `stickyBreakpoint` to specify 
 
 <Canvas>
     <Story name='w/ All Toolbar Options'>
-        <PageHeader
-            overLine="Agency Profile"
-            title="Department of Homeland Security"
-            toolBar={[
-                <FiscalYearPicker
-                    selectedFy={2020}
-                    latestFy={2021}
-                    handleFyChange={() => {}} />,
-                <ShareIcon url='this-is-a-test-url.com' />,
-                <DownloadIconButton onClick={() => {}} downloadInFlight={boolean("Download In Flight", false)} tooltipComponent={<Tooltip />} isEnabled={boolean("Download Enabled", true)} />
-            ]}>
+        <div className="page-header-story">
+            <PageHeader
+                overLine="Agency Profile"
+                title="Department of Homeland Security"
+                toolBar={[
+                    <FiscalYearPicker
+                        selectedFy={2020}
+                        latestFy={2021}
+                        handleFyChange={() => {}} />,
+                    <ShareIcon url='this-is-a-test-url.com' />,
+                    <DownloadIconButton onClick={() => {}} downloadInFlight={boolean("Download In Flight", false)} tooltipComponent={<Tooltip />} isEnabled={boolean("Download Enabled", true)} />
+                ]} />
             <ComingSoon />
-        </PageHeader>
+        </div>
     </Story>
 </Canvas>
 

--- a/components/DownloadIconButton.jsx
+++ b/components/DownloadIconButton.jsx
@@ -3,57 +3,70 @@
  * Created by Lizzie Salita 7/9/20
  **/
 
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner, faFileDownload } from '@fortawesome/free-solid-svg-icons';
 
+import TooltipWrapper from './infoTooltip/TooltipWrapper';
+
 require('../styles/components/_downloadIconButton.scss');
 
 const propTypes = {
-    onClick: PropTypes.func,
+    onClick: PropTypes.func.isRequired,
     downloadInFlight: PropTypes.bool,
-    hoverComponent: PropTypes.element
+    tooltipComponent: PropTypes.element,
+    isEnabled: PropTypes.bool,
+    tooltipPosition: PropTypes.string
 };
 
-const DownloadIconButton = ({ onClick, downloadInFlight, hoverComponent = null }) => {
-    const [showHover, setShowHover] = useState(false);
+const DownloadIconButton = ({
+    onClick,
+    downloadInFlight,
+    tooltipComponent = null,
+    tooltipPosition = "left",
+    isEnabled = true
+}) => {
     const startDownload = (e) => {
         e.preventDefault();
-        if (!downloadInFlight) {
+        if (!downloadInFlight && isEnabled) {
             onClick();
         }
     };
 
-    const onMouseEnter = () => setShowHover(true);
-    const onMouseLeave = () => setShowHover(false);
-
-    let hover = null;
-    if (showHover && !downloadInFlight) {
-        hover = (hoverComponent);
-    }
-
-    const disabledClass = downloadInFlight ? ' sticky-header__button_disabled' : '';
+    const disabledClass = downloadInFlight || !isEnabled ? ' disabled' : '';
     const buttonText = downloadInFlight ? 'Preparing Download...' : 'Download';
     const icon = downloadInFlight ? faSpinner : faFileDownload;
 
+    if (tooltipComponent) {
+        return (
+            <TooltipWrapper
+                className={`usda-download-btn${disabledClass}`}
+                tooltipPosition={tooltipPosition}
+                tooltipComponent={tooltipComponent}>
+                <button
+                    className="usda-button"
+                    title={buttonText}
+                    aria-label={buttonText}
+                    disabled={downloadInFlight}
+                    onClick={startDownload}>
+                    <FontAwesomeIcon icon={icon} spin={downloadInFlight} />
+                </button>
+                <span>{buttonText}</span>
+            </TooltipWrapper>
+        );
+    }
     return (
-        <div
-            className="usda-download-btn"
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onFocus={onMouseEnter}
-            onBlur={onMouseLeave}>
-            {hover}
+        <div className={`usda-download-btn${disabledClass}`}>
             <button
-                className={`usda-button${disabledClass}`}
+                className="usda-button"
                 title={buttonText}
                 aria-label={buttonText}
                 disabled={downloadInFlight}
                 onClick={startDownload}>
-                <FontAwesomeIcon icon={icon} spin={!!downloadInFlight} />
+                <FontAwesomeIcon icon={icon} spin={downloadInFlight} />
             </button>
-            <span>Download</span>
+            <span>{buttonText}</span>
         </div>
     );
 };

--- a/components/PageHeader.jsx
+++ b/components/PageHeader.jsx
@@ -1,65 +1,15 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { isEmpty } from 'lodash';
 
 import { useDynamicStickyClass } from '../helpers/pageHeaderHelper';
-import ShareIcon from './ShareIcon';
-import DownloadIconButton from './DownloadIconButton';
-import FiscalYearPicker from './FiscalYearPicker';
 
 require('../styles/components/_section-title.scss');
 
-const ToolBar = ({
-    fyProps,
-    downloadProps,
-    shareProps,
-    classNames
-}) => (
-    <div className={classNames}>
-        {/* FY Picker */}
-        {!isEmpty(fyProps) && <FiscalYearPicker {...fyProps} />}
-        {/* Share Icon */}
-        {!isEmpty(shareProps) && <ShareIcon {...shareProps} />}
-        {/* Download Icon */}
-        {!isEmpty(downloadProps) && <DownloadIconButton {...downloadProps} />}
-    </div>
-);
-
-ToolBar.propTypes = {
-    classNames: PropTypes.string,
-    fyProps: PropTypes.shape({
-        selectedFy: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-        earliestFy: PropTypes.number,
-        latestFy: PropTypes.number,
-        sortFn: PropTypes.func,
-        handleFyChange: PropTypes.func.isRequired,
-        options: PropTypes.arrayOf(PropTypes.shape({
-            name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-        }))
-    }),
-    shareProps: PropTypes.shape({
-        url: PropTypes.string.isRequired,
-        classNames: PropTypes.string,
-        onShareOptionClick: PropTypes.func.isRequired
-    }),
-    downloadProps: PropTypes.shape({
-        onClick: PropTypes.func.isRequired,
-        downloadInFlight: PropTypes.bool.isRequired,
-        hoverComponent: PropTypes.element
-    })
-};
-
 const PageHeader = ({
     title,
-    children,
-    id = '',
-    classNames = '',
     overLine = "",
-    fyProps,
-    shareProps,
-    downloadProps,
-    stickyBreakPoint = 0
+    stickyBreakPoint = 0,
+    toolBar
 }) => {
     const stickyHeader = useRef(null);
     const [
@@ -83,64 +33,47 @@ const PageHeader = ({
 
     const stickyClass = isSticky ? ' usda-page-header--sticky' : '';
 
-    const showToolbar = (
-        !isEmpty(fyProps) ||
-        !isEmpty(shareProps) ||
-        !isEmpty(downloadProps)
-    );
-
     return (
-        <main id={id} className={`usda-page__container${classNames ? ` ${classNames}` : ''}`}>
-            <section className={`usda-page-header${stickyClass}`} ref={stickyHeader}>
-                <div className="usda-page-header__container">
-                    <div className="usda-page-header__header">
-                        {overLine && <strong className="usda-page-header__overline">{overLine}</strong>}
-                        <div className="usda-page-header__title">
-                            <h1>{title}</h1>
-                        </div>
+        <section className={`usda-page-header${stickyClass}`} ref={stickyHeader}>
+            <div className="usda-page-header__container">
+                <div className="usda-page-header__header">
+                    {overLine && <strong className="usda-page-header__overline">{overLine}</strong>}
+                    <div className="usda-page-header__title">
+                        <h1>{title}</h1>
                     </div>
-                    {showToolbar && React.cloneElement(<ToolBar />, {
-                        classNames: 'usda-page-header__toolbar',
-                        fyProps,
-                        shareProps,
-                        downloadProps
-                    })}
                 </div>
-            </section>
-            {children}
-        </main>
+                {toolBar?.length > 0 && (
+                    <div className="usda-page-header__toolbar">
+                        {toolBar.map((component) => {
+                            const className = `${component.props?.className} ${component.props?.classNames}`;
+                            const classNames = `${component.props?.classNames}`;
+                            if (className) {
+                                return React.cloneElement(component, {
+                                    className: `${className} toolbar__item`
+                                });
+                            }
+                            if (classNames) {
+                                return React.cloneElement(component, {
+                                    classNames: `${classNames} toolbar__item`
+                                });
+                            }
+                            return React.cloneElement(component, {
+                                className: `toolbar__item`,
+                                classNames: `toolbar__item`
+                            });
+                        })}
+                    </div>
+                )}
+            </div>
+        </section>
     );
 };
 
 PageHeader.propTypes = {
-    id: PropTypes.string,
-    classNames: PropTypes.string,
     stickyBreakPoint: PropTypes.number,
     overLine: PropTypes.string,
     title: PropTypes.string.isRequired,
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
-    fyProps: PropTypes.shape({
-        selectedFy: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-        earliestFy: PropTypes.number,
-        latestFy: PropTypes.number,
-        sortFn: PropTypes.func,
-        options: PropTypes.arrayOf(PropTypes.shape({
-            name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-            value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-            classNames: PropTypes.string
-        })),
-        handleFyChange: PropTypes.func.isRequired
-    }),
-    shareProps: PropTypes.shape({
-        url: PropTypes.string.isRequired,
-        classNames: PropTypes.string,
-        onShareOptionClick: PropTypes.func.isRequired
-    }),
-    downloadProps: PropTypes.shape({
-        onClick: PropTypes.func.isRequired,
-        downloadInFlight: PropTypes.bool.isRequired,
-        hoverComponent: PropTypes.element
-    })
+    toolBar: PropTypes.arrayOf(PropTypes.element)
 };
 
 export default PageHeader;

--- a/styles/components/_downloadIconButton.scss
+++ b/styles/components/_downloadIconButton.scss
@@ -1,6 +1,15 @@
 @import "../global/index";
 
 .usda-download-btn {
+    .tooltip__hover-wrapper {
+        flex-direction: column;
+    }
+    &.disabled {
+        .usda-button,
+        span {
+            opacity: 0.5;
+        }
+    }
     .usda-button {
         background-color: $color-base;
         border: none;

--- a/styles/components/_fiscalYearPicker.scss
+++ b/styles/components/_fiscalYearPicker.scss
@@ -4,7 +4,7 @@
     @include for-tablet-portrait-down {
       padding: rem(8) rem(10);
     }
-    .usda-fy-picker {
+    .usa-dt-picker.usda-fy-picker {
       padding: rem(1.5) rem(10);
       background: $color-gray-lightest;
       border: rem(2) solid #AEB0B5;

--- a/styles/components/_pageToolbar.scss
+++ b/styles/components/_pageToolbar.scss
@@ -19,14 +19,14 @@
     font-size: rem(14);
     display: flex;
     justify-content: center;
-    height: rem(18);
   }
 
   @import "./fiscalYearPicker";
 
   .usda-share-icon,
-  .usda-fy-picker {
-    .usa-dt-picker__list {
+  .usda-fy-picker__container,
+  .usa-dt-picker {
+    .usa-dt-picker .usa-dt-picker__dropdown-container .usa-dt-picker__list {
       width: rem(141);
       box-shadow: 0 rem(2) rem(2) 0 rgba(0,0,0,0.5);
       border-radius: rem(3);
@@ -47,10 +47,11 @@
           span {
             color: $color-gray;
           }
-          &:hover, .active {
+          &:hover, &.active {
               background: $color-gray-lightest;
               border: rem(1) solid $color-gray-lightest;
               cursor: pointer;
+              color: $color-link;
           }
           svg {
               margin-right: rem(12);
@@ -75,18 +76,16 @@
   }
 
   .usda-download-btn,
+  .usda-download-btn.tooltip-wrapper,
   .usda-share-icon {
     display: none;
     margin-top: auto;
-    // margin-bottom: auto;
     @include for-tablet-landscape-up {
       display: flex;
       flex-direction: column;
     }
-    // span {
-    //   margin-top: rem(5);
-    // }
-    .usa-dt-picker__button {
+    .usa-dt-picker__button,
+    .usda-button {
       padding: 0;
       margin: 0;
     }

--- a/styles/components/_section-title.scss
+++ b/styles/components/_section-title.scss
@@ -15,6 +15,11 @@ $z-header: 100;
     display: flex;
     width: 100%;
   }
+  &.usda-page-header--sticky {
+    position: fixed;
+    top: 0;
+    z-index: $z-header;
+  }
   .usda-section-title__container,
   .usda-page-header__container {
     flex-wrap: wrap;
@@ -26,16 +31,10 @@ $z-header: 100;
       margin: auto;
       @include for-desktop-up {
         height: rem(60);
-        margin: 0 rem(40);
       }
       @include for-big-desktop-up {
         margin: auto;
       }
-    }
-    &.usda-page-header--sticky {
-        position: fixed;
-        top: 0;
-        z-index: $z-header;
     }
     @include for-tablet-landscape-up {
       flex-wrap: nowrap;

--- a/styles/components/_section-title.scss
+++ b/styles/components/_section-title.scss
@@ -5,34 +5,31 @@ $sticky-header-height-mobile: rem(96);
 $z-header: 100;
 
 .usda-section__container,
-.usda-page__container {
+.usda-page-header {
   margin-top: rem(15);
   margin-bottom: rem(15);
   flex-wrap: wrap;
-  &.usda-page__container {
+  &.usda-page-header {
     margin: 0;
+    background: $color-base;
+    display: flex;
+    width: 100%;
   }
   .usda-section-title__container,
-  .usda-page-header,
-  .usda-page-header .usda-page-header__container {
+  .usda-page-header__container {
     flex-wrap: wrap;
     display: flex;
     align-items: center;
     width: 100%;
-    &.usda-page-header {
-      background: $color-base;
+    &.usda-page-header__container {
+      max-width: 160rem;
+      margin: auto;
       @include for-desktop-up {
         height: rem(60);
+        margin: 0 rem(40);
       }
-      .usda-page-header__container {
-        max-width: 160rem;
+      @include for-big-desktop-up {
         margin: auto;
-        @include for-desktop-up {
-          margin: 0 rem(40);
-        }
-        @include for-big-desktop-up {
-          margin: auto;
-        }
       }
     }
     &.usda-page-header--sticky {

--- a/styles/demo-pages/_section-title.scss
+++ b/styles/demo-pages/_section-title.scss
@@ -2,7 +2,7 @@
   margin-top: rem(20);
 }
 
-.usda-page__container {
+.page-header-story {
   height: 1600px;
   .usda-page-header.usda-page-header--sticky {
     width: calc(100% - 20px);
@@ -19,7 +19,7 @@
 }
 
 .docs-story {
-  .usda-page__container {
+  .page-header-story {
     height: auto;
     .usda-page-header.usda-page-header--sticky {
       width: 100%;


### PR DESCRIPTION
- Allowing consumer to pass components rather than just component props
for greater flexibility in what is in the toolbar.

- Updating specificity for css selectors to maintain styles

## Check List Before Merging
### Author
- [x] Story Book has been rebuilt (new build artifacts in `/docs`)
- [x] Components have been rebuilt (new build artifacts in `/dist`)

👆 These can be done by executing `npm run build` and committing the build artifacts.

`N/A`  All new components have been exported in `/index.js` `(if applicable)`
`N/A` Design Review Complete
- [x] Relevant Draft release notes have been updated describing these changes ([use this template](https://github.com/fedspendingtransparency/data-transparency-ui/blob/master/release_notes_template.md) to document your changes) `(if applicable)`
`N/A` Integration Status Updated on relevant documentation page `(if applicable)`
- [x] `index.d.ts` updated with new prop types defined for new components. `(if applicable)`

### Reviewer
- [ ] Code review
